### PR TITLE
(feature) only grab posts for specific forum

### DIFF
--- a/client/app/posts/posts.html
+++ b/client/app/posts/posts.html
@@ -1,9 +1,7 @@
 <div id="posts-container">
 
   <div class="posts" ng-repeat="post in posts |
-    orderBy:'-post.created':true |
-    filter: searchFor |
-    filter: { forum: forum }">
+    orderBy:'-post.created':true">
 
     <a ui-sref="post({forum: forum, postId: post._id})">
       <h2 ng-bind="post.title"></h2>

--- a/client/app/posts/posts.js
+++ b/client/app/posts/posts.js
@@ -13,7 +13,7 @@ angular.module('hackoverflow.posts', [
 
   $scope.getPosts = function getPosts(forum) {
     // TODO: need to pass in forum to Posts.getPosts()
-    Posts.getPosts('').then(function (data) {
+    Posts.getPosts(forum).then(function (data) {
       $scope.posts = data.data;
       // this creates an object $scope.numberOfAnswers that
       // keeps track of each posts number of Answers. not

--- a/server/posts/postController.js
+++ b/server/posts/postController.js
@@ -82,7 +82,7 @@ module.exports = {
   //     })
   //   });
   // },
-  
+
   // deletes post and it answer children
   deletePost: function (request, response, next) {
    request.post.answers.forEach(function (id) {
@@ -114,7 +114,12 @@ module.exports = {
  },
 
  getPostForum: function (request, response, next) {
-  Post.find({}).select({ forum: request.body.post.forum })
+  Post.find({forum: request.params.forum}, function(err, posts) {
+    if (err) {
+      return next(err);
+    }
+    response.json(posts);
+  })
  }
 
 };

--- a/server/posts/postRoutes.js
+++ b/server/posts/postRoutes.js
@@ -40,10 +40,10 @@ app.param('answer', function (req, res, next, id) {
 });
 
   // app = postRouter injected from middleware.js
+    app.get('/:forum', postController.getPostForum);
     app.get('/', postController.getPosts);
     app.post('/', postController.newPost);
     app.get('/:post', postController.getPost);
     app.put('/:post', postController.editPost);
     app.delete('/:post', postController.deletePost);
-    app.get('/:forum', postController.getPostForum);
 };


### PR DESCRIPTION
Previously, we were grabbing all posts regardless of which forum we were visiting, then filtering them on the client-side. This change will only grab posts for the specific forum we want. This way we can display a message when there are no posts for a specific forum
